### PR TITLE
Reconnection was not clearing closed property

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -56,6 +56,7 @@ export default class BeanstalkdClient {
       connection.on('connect', () => {
         debug('connected to %s:%s', this.host, this.port);
         this.connection = connection;
+        this.closed = false;
         this.readQueue = new ReadQueue(this.connection);
         resolve(this);
       });


### PR DESCRIPTION
While reconnect logic is not handled in this library, it was expected that after reconnecting, the Beanstalkd instance would be usable again. However the `closed` property will stay `true` after a reconnect is initiated by the user, and the instance is still unusable throwing `Error: Connection is closed` when it is actually open.

This commit sets the `closed` property to false after connecting, which ensures reconnections render the instance usable again.