### PR TITLE
Should calculate the right length of args

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -82,7 +82,9 @@ export default class BeanstalkdClient {
 
     if (spec.args.indexOf('bytes') > -1) {
       let data = args.pop();
-      args.push(data.length);
+
+      let b = new Buffer(data);
+      args.push(b.length);
       args.push(data);
     }
 


### PR DESCRIPTION
There is a bug in beanstalkd-client where if you use extended characters such as smileys the beanstalkd server replies with No CRLF. This is due to the library incorrectly counting bytes (e.g. it counts characters, not bytes).

Kindly accept this pull request which fixes the bug and adds an integration test for it.